### PR TITLE
Add msgpack serializer capable of decoding posix timestamp in milliseconds

### DIFF
--- a/skinport/client.py
+++ b/skinport/client.py
@@ -32,6 +32,7 @@ import socketio
 from asyncache import cached
 from cachetools import TTLCache
 
+from .skinport_msgpack_packet import SkinportMsgPackPacket
 from .enums import AppID, Currency, Locale
 from .http import HTTPClient
 from .item import Item, ItemOutOfStock, ItemWithSales
@@ -167,7 +168,7 @@ class Client:
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         http_session = aiohttp.ClientSession(connector=connector)
         self.ws: socketio.AsyncClient = socketio.AsyncClient(
-            serializer="msgpack", http_session=http_session, timestamp_requests=False
+            serializer=SkinportMsgPackPacket, http_session=http_session, timestamp_requests=False
         )
 
         # Attach the listeners

--- a/skinport/salefeed.py
+++ b/skinport/salefeed.py
@@ -212,7 +212,7 @@ class SaleFeedSale:
         self._image = data.get("image", "")
         self._classid = data.get("classid", "")
         self._assetid = data.get("assetid", "")
-        self._lock = data.get("lock", "1970-01-01T00:00:00.000Z")
+        self._lock = data.get("lock", None)
         self._version = data.get("version", "")
         self._versionType = data.get("versionType", "")
         self._stackAble = data.get("stackAble", False)
@@ -358,9 +358,9 @@ class SaleFeedSale:
         return self._assetid
 
     @property
-    def lock(self) -> datetime.datetime:
-        """:class:`datetime.datetime`: Returns the time until the item is trade-locked."""
-        return datetime.datetime.strptime(self._lock, "%Y-%m-%dT%H:%M:%S.%fZ")
+    def lock(self) -> Optional[datetime.datetime]:
+        """Optional[:class:`datetime.datetime`]`: Returns the time until the item is trade-locked."""
+        return self._lock.to_datetime() if self._lock is not None else None
 
     @property
     def version(self) -> str:

--- a/skinport/skinport_msgpack_packet.py
+++ b/skinport/skinport_msgpack_packet.py
@@ -1,0 +1,41 @@
+import struct
+
+import msgpack
+from msgpack import Timestamp, ExtType
+from socketio.msgpack_packet import MsgPackPacket
+
+
+class SkinportMsgPackPacket(MsgPackPacket):
+
+    def encode(self):
+        """Encode the packet for transmission."""
+        return msgpack.dumps(self._to_dict(), default=self._default)
+
+    def decode(self, encoded_packet):
+        """Decode a transmitted package."""
+        decoded = msgpack.loads(encoded_packet, ext_hook=self._ext_hook)
+        self.packet_type = decoded['type']
+        self.data = decoded.get('data')
+        self.id = decoded.get('id')
+        self.namespace = decoded['nsp']
+
+    def _ext_hook(self, code, data):
+        if code == 0 and len(data) == 8:
+            return self._decode_timestamp_from_ext(code, data)
+        return ExtType(code, data)
+
+    @staticmethod
+    def _decode_timestamp_from_ext(code, data):
+        milliseconds = struct.unpack("!Q", data)[0]
+        return Timestamp.from_unix(milliseconds / 1000)
+
+    def _default(self, obj):
+        if isinstance(obj, Timestamp):
+            return self._encode_timestamp_to_ext(obj)
+        return obj
+
+    @staticmethod
+    def _encode_timestamp_to_ext(obj):
+        milliseconds = int(obj.to_unix() * 1000)
+        return ExtType(0, struct.pack("!Q", milliseconds))
+

--- a/tests/test_skinport_msgpack_packet.py
+++ b/tests/test_skinport_msgpack_packet.py
@@ -1,0 +1,124 @@
+import datetime
+import unittest
+
+import msgpack
+
+from skinport.skinport_msgpack_packet import SkinportMsgPackPacket
+
+
+class SkinportMsgPackPacketTestCase(unittest.TestCase):
+
+    def test_encode(self):
+        # Given
+        given_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        given_timestamp = msgpack.Timestamp.from_datetime(given_dt)
+        given_packet = SkinportMsgPackPacket(packet_type=2, data=given_timestamp, namespace='/')
+        # When
+        encoded_packet = given_packet.encode()
+        # Then
+        expected_encoded_packet = b'\x83\xa4type\x02\xa4data\xd6\xffg\xa8`\x80\xa3nsp\xa1/'
+        self.assertEqual(expected_encoded_packet, encoded_packet)
+
+    def test_decode(self):
+        # Given
+        encoded_packet = b'\x83\xa4type\x02\xa4data\xd6\xffg\xa8`\x80\xa3nsp\xa1/'
+        # When
+        decoded_packet = SkinportMsgPackPacket()
+        decoded_packet.decode(encoded_packet)
+        # Then
+        expected_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        self.assertEqual(2, decoded_packet.packet_type)
+        self.assertEqual(expected_dt, decoded_packet.data.to_datetime())
+        self.assertIsNone(decoded_packet.id)
+        self.assertEqual('/', decoded_packet.namespace)
+
+    def test_encode_and_decode_packet(self):
+        # Given
+        given_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        given_timestamp = msgpack.Timestamp.from_datetime(given_dt)
+        given_packet = SkinportMsgPackPacket(packet_type=2, data=given_timestamp, namespace='/')
+        # When
+        encoded_packet = given_packet.encode()
+        decoded_packet = SkinportMsgPackPacket()
+        decoded_packet.decode(encoded_packet)
+        # Then
+        self.assertEqual(given_packet._to_dict(), decoded_packet._to_dict())
+
+    def test_default(self):
+        with self.subTest('When object is not a Timestamp'):
+            # Given
+            given_obj = 'not a Timestamp'
+            # When
+            result = SkinportMsgPackPacket()._default(given_obj)
+            # Then
+            self.assertEqual(given_obj, result)
+
+        with self.subTest('When object is a Timestamp'):
+            # Given
+            given_obj = msgpack.Timestamp(0, 0)
+            # When
+            result = SkinportMsgPackPacket()._default(given_obj)
+            # Then
+            self.assertIsInstance(result, msgpack.ExtType)
+
+    def test_ext_hook(self):
+        with self.subTest('When code is not 0 and data length is 8'):
+            # Given
+            given_code = 1
+            given_data = b'\x00\x00\x01\x94\xe9\xb8\xf4'
+            # When
+            result = SkinportMsgPackPacket()._ext_hook(given_code, given_data)
+            # Then
+            self.assertIsInstance(result, msgpack.ExtType)
+            self.assertEqual(1, result.code)
+            self.assertEqual(b'\x00\x00\x01\x94\xe9\xb8\xf4', result.data)
+
+        with self.subTest('When code is 0 and data length is not 8'):
+            # Given
+            given_code = 0
+            given_data = b'\x00\x00\x01\x94\xe9\xb8\xf4'
+            # When
+            result = SkinportMsgPackPacket()._ext_hook(given_code, given_data)
+            # Then
+            self.assertIsInstance(result, msgpack.ExtType)
+            self.assertEqual(0, result.code)
+            self.assertEqual(b'\x00\x00\x01\x94\xe9\xb8\xf4', result.data)
+
+        with self.subTest('When code is 0 and data length is 8'):
+            # Given
+            given_code = 0
+            given_data = b'\x00\x00\x01\x94\xe9\xb8\xf4\x00'
+            # When
+            result = SkinportMsgPackPacket()._ext_hook(given_code, given_data)
+            # Then
+            self.assertIsInstance(result, msgpack.Timestamp)
+            self.assertEqual(datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc), result.to_datetime())
+
+    def test_encode_timestamp_to_ext(self):
+        # Given
+        given_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        given_timestamp = msgpack.Timestamp.from_datetime(given_dt)
+        # When
+        ext_type = SkinportMsgPackPacket._encode_timestamp_to_ext(given_timestamp)
+        # Then
+        expected_ext_type = msgpack.ExtType(0, b'\x00\x00\x01\x94\xe9\xb8\xf4\x00')
+        self.assertEqual(expected_ext_type, ext_type)
+
+    def test_decode_timestamp_from_ext(self):
+        # Given
+        given_ext_type = msgpack.ExtType(0, b'\x00\x00\x01\x94\xe9\xb8\xf4\x00')
+        # When
+        timestamp = SkinportMsgPackPacket._decode_timestamp_from_ext(*given_ext_type)
+        # Then
+        expected_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        self.assertEqual(expected_dt, timestamp.to_datetime())
+
+    def test_encode_and_decode_timestamp(self):
+        # Given
+        given_dt = datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc)
+        given_timestamp = msgpack.Timestamp.from_datetime(given_dt)
+        # When
+        ext_type = SkinportMsgPackPacket._encode_timestamp_to_ext(given_timestamp)
+        timestamp = SkinportMsgPackPacket._decode_timestamp_from_ext(*ext_type)
+        # Then
+        self.assertEqual(given_dt, timestamp.to_datetime())


### PR DESCRIPTION
The `lock` attribute of the sale feed is encoded as posix timestamp in milliseconds. Unlike the typical posix timestamp in seconds, this encoding requires a separate decoding which is not implemented in `msgpack-python`.

This PR adds a custom `msgpack` serializer called `SkinportMsgPackPacket` as drop-in replacement for the default `msgpack` implementation used by the `socketio` websocket.