### PR TITLE
Add EventType Enum for SaleFeed Events

### DIFF
--- a/skinport/enums.py
+++ b/skinport/enums.py
@@ -29,6 +29,7 @@ __all__ = (
     "Currency",
     "Exterior",
     "Locale",
+    "EventType",
     "SaleType",
     "TransactionType",
     "SteamStatus",
@@ -75,6 +76,14 @@ class Locale(Enum):
     fi = "fi"
     es = "es"
     tr = "tr"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class EventType(Enum):
+    listed = "listed"
+    sold = "sold"
 
     def __str__(self) -> str:
         return self.value

--- a/skinport/salefeed.py
+++ b/skinport/salefeed.py
@@ -26,7 +26,7 @@ import datetime
 from typing import Any, Dict, List, Optional
 
 from .color import Color
-from .enums import AppID, Currency, SaleType
+from .enums import AppID, Currency, SaleType, EventType
 
 __all__ = ("SaleFeed", "SaleFeedSale", "Sticker", "Tag", "Charm")
 
@@ -653,9 +653,9 @@ class SaleFeed:
         return f"<SaleFeed event_type={self._event_type}>"
 
     @property
-    def event_type(self) -> str:
-        """:class:`str`: Returns the type of the event."""
-        return self._event_type
+    def event_type(self) -> EventType:
+        """:class:`EventType`: Returns the type of the event."""
+        return EventType(self._event_type)
 
     @property
     def sales(self) -> List[SaleFeedSale]:


### PR DESCRIPTION
## Summary
This PR introduces a new `EventType` enum in `skinport/enums.py` and integrates it into the `SaleFeed` class in `skinport/salefeed.py`. It replaces the current string-based `event_type` representation with a typed enum for increased clarity, consistency, and robustness in downstream usage.

## Changes
- Added `EventType` enum with `listed` and `sold` values.
- Updated `__all__` list in `enums.py` to include `EventType`.
- Changed return type of `SaleFeed.event_type` from `str` to `EventType`.
- Updated the `event_type` property to cast from string to `EventType`.

## Motivation
By using a dedicated enum for event types, the code:
- Gains **type safety**, which helps with linting and auto-completion in IDEs.
- Becomes **more self-documenting**, especially when inspecting or filtering event types.
- Aligns with the existing use of enums (e.g. `SaleType`, `Currency`) in the library.

## Example Migration
Before:
```python
if sale_feed.event_type == "sold":
    ...
```
After:
```python
from skinport.enums import EventType

if sale_feed.event_type == EventType.sold:
    ...
```