### PR TITLE
Add TransactionStatus Enum for Transactions

### DIFF
--- a/skinport/enums.py
+++ b/skinport/enums.py
@@ -30,6 +30,7 @@ __all__ = (
     "Exterior",
     "Locale",
     "SaleType",
+    "TransactionStatus",
     "TransactionType",
     "SteamStatus",
 )
@@ -96,6 +97,15 @@ class Exterior(Enum):
     battle_scarred = "Battle-Scarred"
 
     def __str__(self) -> str:
+        return self.value
+
+
+class TransactionStatus(Enum):
+    initiate = 'initiate'
+    canceled = 'canceled'
+    complete = 'complete'
+
+    def __str__(self):
         return self.value
 
 

--- a/skinport/transaction.py
+++ b/skinport/transaction.py
@@ -25,7 +25,7 @@ SOFTWARE.
 import datetime
 from typing import Any, Dict, List, Optional
 
-from .enums import Currency, TransactionType
+from .enums import Currency, TransactionStatus, TransactionType
 
 __all__ = (
     "Transaction",
@@ -146,9 +146,9 @@ class Transaction:
         return self._sub_type
 
     @property
-    def status(self) -> str:
-        """:class:`str`: Returns the transaction status."""
-        return self._status
+    def status(self) -> TransactionStatus:
+        """:class:`TransactionStatus`: Returns the transaction status."""
+        return TransactionStatus(self._status)
 
     @property
     def amount(self) -> float:


### PR DESCRIPTION
## Summary
This PR introduces the `TransactionStatus` enum to `skinport/enums.py` and integrates it into the `Transaction` class in `skinport/transaction.py`. It replaces the existing string-based `status` with a typed enum to promote clarity, consistency, and type safety.

## Changes
- Added `TransactionStatus` enum with values: `initiate`, `canceled`, `complete`.
- Updated `__all__` in `enums.py` to export `TransactionStatus`.
- Modified the `Transaction.status` property to return a `TransactionStatus` instance instead of a raw string.

## Motivation
This change follows the project's existing convention of using enums for categorical values such as `TransactionType`, `SaleType`, and others. Benefits include:
- Improved type checking and IDE support.
- Minimized risk of typos or invalid string literals.
- Better documentation and usability through clear, typed interfaces.

## Example Migration
Before:
```python
if transaction.status == "complete":
    ...
```
After:
```python
from skinport.enums import TransactionStatus

if transaction.status == TransactionStatus.complete:
    ...
```
