### PR TITLE
Add MaintenanceStatus Enum for Sale Feed maintenanceUpdated Event

### DIFF
--- a/skinport/enums.py
+++ b/skinport/enums.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from enum import Enum, IntEnum
+from enum import Enum, Flag, IntEnum
 
 __all__ = (
     "AppID",
@@ -33,6 +33,7 @@ __all__ = (
     "SaleType",
     "TransactionStatus",
     "TransactionType",
+    "MaintenanceStatus",
     "SteamStatus",
 )
 
@@ -125,6 +126,11 @@ class TransactionType(Enum):
 
     def __str__(self):
         return self.value
+
+
+class MaintenanceStatus(Flag):
+    false = False
+    true = True
 
 
 class SteamStatus(Enum):


### PR DESCRIPTION
## Summary
This PR introduces a `MaintenanceStatus` enum in `skinport/enums.py` to represent the `maintenanceUpdated` event status in the WebSocket-based Sale Feed. This provides a typed interface over previously untyped Boolean flags.

## Changes
- Introduced `MaintenanceStatus` enum (as a subclass of `Flag`) with values: `true` and `false`.
- Exported `MaintenanceStatus` via `__all__` in `enums.py`.

## Motivation
The `maintenanceUpdated` WebSocket event communicates boolean status flags. Typing them with an enum:
- Aligns with the library's enum-centric API design.
- Makes the code more readable, self-documenting, and type-safe.
- Enables potential future expansion or bitwise operations (hence `Flag`).

## Example Migration
Before:
```python
def on_maintenance_updated(self, data: bool) -> None:
    if data is True:
        ...
```
After:
```python
from skinport.enums import MaintenanceStatus

def on_maintenance_updated(self, data: bool) -> None:
    maintenance_status = MaintenanceStatus(data)

    if maintenance_status == MaintenanceStatus.true:
        ...
```