### PR TITLE
Add `reference_price` Field to SaleFeed Item

### DIFF
--- a/skinport/salefeed.py
+++ b/skinport/salefeed.py
@@ -284,6 +284,7 @@ class SaleFeedSale:
         "_subCategory",
         "_subCategory_localized",
         "_suggestedPrice",
+        "_referencePrice",
         "_tags",
         "_text",
         "_title",
@@ -321,6 +322,7 @@ class SaleFeedSale:
         self._versionType = data.get("versionType", "")
         self._stackAble = data.get("stackAble", False)
         self._suggestedPrice = data.get("suggestedPrice", 0)
+        self._referencePrice = data.get("referencePrice", 0)
         self._salePrice = data.get("salePrice", 0)
         self._currency = data.get("currency", "")
         self._saleStatus = data.get("saleStatus", "")
@@ -494,6 +496,11 @@ class SaleFeedSale:
     def suggested_price(self) -> float:
         """:class:`float`: Returns the suggested sale price of the item."""
         return self._suggestedPrice / 100
+
+    @property
+    def reference_price(self) -> float:
+        """:class:`float`: Returns the reference price of the item."""
+        return self._referencePrice / 100
 
     @property
     def sale_price(self) -> float:


### PR DESCRIPTION
This pull request introduces support for a new field, `reference_price`, in the `SaleFeed` item model. This field reflects the reference market price of the item, independent of the current sale or suggested price.

#### Changes:
- Added `_referencePrice` to the list of tracked fields.
- Initialized `_referencePrice` in the constructor with a default value of 0 if the field is missing in the input data.
- Introduced a `reference_price` property that exposes the reference price as a `float` (converted from cents).
